### PR TITLE
fix: Fix a hang issue on RDK X3 V1.2

### DIFF
--- a/board/hobot/common/board.c
+++ b/board/hobot/common/board.c
@@ -2192,6 +2192,7 @@ void reset_lt8618(void)
 	switch (som_type)
 	{
 	case SOM_TYPE_X3PI:
+	case SOM_TYPE_X3PIV2:
 	{
 		reset_pin = 117;
 		reverse = true;
@@ -2207,12 +2208,14 @@ void reset_lt8618(void)
 		reset_pin = 115;
 		break;
 	default:
-		printf("%s :There is nothing to do,return!", __func__);
+		printf("%s :There is nothing to do,return!\n", __func__);
 		break;
 	}
-	set_pin_output_value(reset_pin, reverse?0:1);
-	msleep(100);
-	set_pin_output_value(reset_pin,  reverse?1:0);
+	if(reset_pin != 0){
+		set_pin_output_value(reset_pin, reverse?0:1);
+		msleep(100);
+		set_pin_output_value(reset_pin,  reverse?1:0);
+	}
 }
 int board_early_init_f(void)
 {

--- a/board/hobot/xj3/xj3.c
+++ b/board/hobot/xj3/xj3.c
@@ -517,7 +517,7 @@ static int board_usbkbd_scan(void)
 		vbus_pin = 64;
 		break;
 	default:
-		printf("%s :There is nothing to do,return!", __func__);
+		printf("%s :There is nothing to do,return!\n", __func__);
 		break;
 	}
 	if(vbus_pin != 0){

--- a/board/hobot/xj3/xj3_set_pin.c
+++ b/board/hobot/xj3/xj3_set_pin.c
@@ -181,10 +181,11 @@ void dump_pin_info(void)
 uint8_t get_lt8618_rst(void)
 {
 	uint32_t som_type = hb_som_type_get();
-	uint8_t reset_pin = -1;
+	uint8_t reset_pin = 0;
 	switch (som_type)
 	{
 	case SOM_TYPE_X3PI:
+	case SOM_TYPE_X3PIV2:
 		reset_pin = 117;
 		break;
 	case SOM_TYPE_X3PIV2_1:
@@ -194,7 +195,7 @@ uint8_t get_lt8618_rst(void)
 		reset_pin = 115;
 		break;
 	default:
-		printf("%s :There is nothing to do,return!", __func__);
+		printf("%s :There is nothing to do,return!\n", __func__);
 		break;
 	}
 	return reset_pin;

--- a/drivers/video/hobot/hobot_xj3_hdmi_lt8618.c
+++ b/drivers/video/hobot/hobot_xj3_hdmi_lt8618.c
@@ -1344,6 +1344,7 @@ static int lt8618_detect(void)
 	switch (som_type)
 	{
 	case SOM_TYPE_X3PI:
+	case SOM_TYPE_X3PIV2:
 	case SOM_TYPE_X3PIV2_1:
 		i2c_bus = 1;
 		break;
@@ -1351,7 +1352,7 @@ static int lt8618_detect(void)
 		i2c_bus = 5;
 		break;
 	default:
-		printf("%s :There is nothing to do,return!", __func__);
+		printf("%s :There is nothing to do,return!\n", __func__);
 		break;
 	}
 	return i2c_bus;


### PR DESCRIPTION
Summary:
	The reason is that the HDMI chip is not reset, and then the I2C bus of X3 keeps timing out and retrying.